### PR TITLE
Added missing tiles specs

### DIFF
--- a/Super Mario Bros/smb.json
+++ b/Super Mario Bros/smb.json
@@ -10,6 +10,8 @@
         ">" : ["solid","top-right pipe","pipe"],
         "[" : ["solid","left pipe","pipe"],
         "]" : ["solid","right pipe","pipe"],
-        "o" : ["coin","collectable","passable"]
+        "o" : ["coin","collectable","passable"],
+        "B" : ["Cannon top","cannon","solid","hazard"],
+        "b" : ["Cannon bottom","cannon","solid"]
     }
 }


### PR DESCRIPTION
fix for issue "Tile type 'B' and 'b' not defined in Super Mario Bros / Processed levels"